### PR TITLE
Updated networkx version range

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ build:
     - langchain-server = langchain.server:main
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  number: 1
+  number: 2
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -80,7 +80,7 @@ requirements:
     - sentence-transformers >=2.0.0,<3.0.0
     - arxiv >=1.4.0,<2.0.0
     - pypdf >=3.4.0,<4.0.0
-    - networkx >=2.6.3,<3.0.0
+    - networkx >=2.6.3,<4
     - aleph-alpha-client >=2.15.0,<3.0.0
     - deeplake >=3.6.8,<4.0.0
     - libdeeplake >=0.0.60,<0.0.61


### PR DESCRIPTION
This PR updates the range for the optional dependency `networkx`, which was updated in v0.0.305 of `LangChain`.
https://github.com/langchain-ai/langchain/pull/11094


### Checklist

* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

